### PR TITLE
angular.js bugfix - interface ILogProvider extends IServiceProvider (…

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -862,7 +862,7 @@ declare module angular {
         warn: ILogCall;
     }
 
-    interface ILogProvider {
+    interface ILogProvider extends IServiceProvider {
         debugEnabled(): boolean;
         debugEnabled(enabled: boolean): ILogProvider;
     }


### PR DESCRIPTION
…missing .$get method)

There is a [`$logProvider`](https://docs.angularjs.org/api/ng/provider/$logProvider) in angular, here are the relevant source lines: https://github.com/angular/angular.js/blob/master/src/ng/log.js#L47-L67. It contains `.$get` method.

in Denifitely Typed, there is only:

```
    interface ILogProvider {
        debugEnabled(): boolean;
        debugEnabled(enabled: boolean): ILogProvider;
    }
```

(https://github.com/borisyankov/DefinitelyTyped/blob/master/angularjs/angular.d.ts#L865-L868). Note, there is no `.$get` method. THe interface should have extended ``IServiceProvider , i.e. `interface ILogProvider extends IServiceProvider`.